### PR TITLE
get rid of lodash dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-hubble",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A better way to select elements for UI testing in Vue",
   "main": "dist/bundle.js",
   "scripts": {
@@ -32,8 +32,5 @@
     "rollup-plugin-node-resolve": "^4.0.1",
     "vue": "^2.6.10",
     "vue-template-compiler": "^2.6.10"
-  },
-  "dependencies": {
-    "lodash": "^4.17.11"
   }
 }

--- a/src/directive.js
+++ b/src/directive.js
@@ -1,7 +1,5 @@
-import _ from 'lodash';
-
 function getRealValue(context, value) {
-  const namespace = _.get(context, '$options.hubble.namespace');
+  const namespace = context.$options.hubble.namespace;
 
   return namespace ? `${namespace}--${value}` : value;
 }

--- a/src/directive.js
+++ b/src/directive.js
@@ -1,8 +1,11 @@
 function getRealValue(context, value) {
-  const namespace = context.$options.hubble.namespace;
-
-  return namespace ? `${namespace}--${value}` : value;
-}
+  if (context.$options && context.$options.hubble) {
+    const namespace = context.$options.hubble.namespace;
+    return namespace ? `${namespace}--${value}` : value;
+  } else {
+    return value;
+  }
+};
 
 function handleHook(element, { arg, value, oldValue }, { context }) {
   if (process.env.NODE_ENV !== 'test') return;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import directive from './directive';
 
 let installed = false;
@@ -9,7 +7,7 @@ const defaultConfig = {
 };
 
 function install(Vue, options = {}) {
-  Vue.prototype.$hubble = _.defaults(options, defaultConfig);
+  Vue.prototype.$hubble = Object.assign({}, defaultConfig, options);
 
   if (!installed) {
     Vue.directive('hubble', directive);


### PR DESCRIPTION
Thanks for providing this nice helper library!

I've noticed that whole lodash is pulled just for 2 methods where it's used
So I tweaked the code to avoid using lodash, to make the lib even smaller and nicer ;)